### PR TITLE
docs: enrich datascience-showcase README and add notebook-setup deep-dive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,12 +10,124 @@ PureSkill.gg Data Science Showcase
    :target: https://github.com/pureskillgg/datascience-showcase/actions
    :alt: GitHub Actions
 
-Showcase of public PureSkill.gg data set applications.
+A small published Python package plus example Jupyter notebooks that demonstrate
+analyzing PureSkill.gg's public CS:GO/CS2 data set, read from a local "tome"
+collection via ``pureskillgg-dsdk``.
 
-Description
------------
+What it does
+------------
 
-TODO
+This repo is a public, analyst-facing **showcase**, not a production service. It
+has two halves:
+
+- A thin published package, ``pureskillgg_datascience_showcase``, whose real job
+  is to bootstrap a Jupyter notebook so it can find and read a local tome data
+  set. The rest of the package is template skeleton (a no-op ``todo`` placeholder).
+- A ``notebooks/`` directory containing the actual worked analyses against the
+  public data set.
+
+The bootstrap path works like this: a notebook calls
+``setup_notebook()``, which loads a ``../.env`` file via python-dotenv_ and echoes
+the ``PURESKILLGG_TOME_*`` environment variables that tell the dsdk tome curator
+where the local CSDS tome collection lives. The notebook then instantiates
+``pureskillgg_dsdk.tome.TomeCuratorFs`` (the **local-filesystem** tome reader,
+not an S3 reader) and loads named tome dataframes for analysis with pandas,
+numpy, matplotlib, and seaborn.
+
+The example notebooks under ``notebooks/`` are the showcase content:
+
+- **Disconnect reason analysis** (``notebooks/player_disconnect_analysis/``)
+  loads the ``channel_player_disconnect`` tome, normalizes and buckets disconnect
+  reasons (e.g. ``Kicked by Console``, ``VAC authentication error``,
+  ``VAC banned from secure server``, timeouts) across tens of thousands of
+  matches, then tabulates and plots the counts as charts branded
+  "Data provided by PureSkill.gg".
+- **M4 usage analysis June 2022** (``notebooks/M4 shift june 2022/``) loads the
+  ``channel_player_death`` tome (millions of kill rows), derives a match date from
+  each ``match_key``, and measures how the June 2022 CS:GO patch shifted the kill
+  share between the M4A4 and the M4A1-S around the patch date. Note: in this data
+  set the raw ``weapon_name`` value ``m4a1`` denotes the **M4A4** (renamed to
+  ``m4a4_kills`` in the notebook), while ``m4a1_silencer`` / ``m4a1_silencer_off``
+  denote the **M4A1-S** (renamed to ``m4a1_kills``).
+- A starter **template** (``notebooks/template/template.ipynb``) plus
+  ``notebooks/usual_suspects.py``, a shared import/boilerplate snippet
+  (pandas / numpy / matplotlib + ``TomeCuratorFs``) that notebooks ``%load``. The
+  template demonstrates ``curator.make_tome(...)`` with ``ds_reading_instructions``
+  to select specific channels and columns.
+
+For a walkthrough of the tome-curator setup and the ``.env`` variables, see
+`docs/notebook-setup.md <docs/notebook-setup.md>`_.
+
+Pipeline role
+-------------
+
+This sits at the very downstream / consumer end of the PureSkill.gg pipeline and
+is **not** part of the production match-processing flow. The production pipeline
+parses demos into CSDS channel data, which is rolled up into "tome" data sets and
+published (including via AWS Data Exchange). This repo's notebooks load those
+tomes from a **local filesystem** collection (for example ``H:\CSDS_tomes\`` for
+the disconnect notebook and ``H:\CSDS_tomes_ADX\`` for the M4 notebook) using
+``TomeCuratorFs``.
+
+It consumes tome data; nothing downstream consumes this repo. It is a public PyPI
+package and a demonstration, not a service.
+
+Major modules and notebooks
+---------------------------
+
+Confirmed components, by their real names:
+
+- ``setup_notebook`` (``pureskillgg_datascience_showcase/notebook/setup_notebook.py``)
+  — notebook bootstrap; loads ``../.env`` and echoes the tome paths. Imported by
+  all three example notebooks.
+- ``setup_env_from_dotenv`` / ``echo_paths`` / ``echo`` / ``get_env_var``
+  (``pureskillgg_datascience_showcase/env_functions/env_setup.py``) — load
+  ``../.env`` via python-dotenv and read/print the ``PURESKILLGG_TOME_*`` env vars.
+  The ``ENV_PREFIX`` is ``pureskillgg_tome``; the echoed names are
+  ``PURESKILLGG_TOME_DEFAULT_HEADER_NAME``, ``PURESKILLGG_TOME_DS_TYPE``,
+  ``PURESKILLGG_TOME_COLLECTION_PATH``, and ``PURESKILLGG_TOME_DS_COLLECTION_PATH``.
+- ``todo`` (``pureskillgg_datascience_showcase/todo.py``) — placeholder skeleton
+  function that returns its argument; the package is otherwise a template.
+- ``notebooks/player_disconnect_analysis/Disconnect reason analysis.ipynb`` — the
+  disconnect-reason notebook.
+- ``notebooks/M4 shift june 2022/M4 usage analysis June 2022.ipynb`` — the
+  M4 kill-share notebook.
+- ``notebooks/usual_suspects.py`` and ``notebooks/template/template.ipynb`` —
+  shared boilerplate and a ``make_tome`` starter template.
+
+Dependencies of note: ``pureskillgg-dsdk`` (the tome curator), plus
+``pureskillgg-csgo-dsdk``, with ``numpy<2`` and ``pandas<2`` pins. These are the
+pre-Python-migration 1.x betas, consistent with a not-yet-fully-modernized
+showcase. This was also the **first uv-migrated** PureSkill.gg repo, so its
+tooling is uv-based (see the ``Makefile``).
+
+Logs and observability
+----------------------
+
+This repo owns **no cloud resources**: no DynamoDB, SQS/DLQ, SNS, S3, Lambda,
+Step Functions, EventBridge, AppSync, CloudFront, or API Gateway, and no IaC of
+any kind (no ``serverless*.yml``, ``*.tf``, ``cdk.json``, or SAM template). It
+reads only a local ``../.env`` and local tome files through ``TomeCuratorFs``.
+``boto3`` appears only as a transitive lock-file dependency (via
+``pureskillgg-dsdk``) and is not used by any source file. There are therefore no
+CloudWatch log groups, DLQs, Sentry, or runtime ``LOG_LEVEL`` handling.
+
+Failures surface only in development and CI:
+
+- **Locally**, via the Makefile: ``make test`` (pytest + coverage), ``make lint``
+  (pylint + ``black --check``), and ``make watch`` (pytest-watch). Notebook
+  problems surface as cell output / tracebacks when running ``make notebook``.
+- **In CI**, as red checks in the GitHub Actions UI. Workflows: ``main.yml``
+  (build/test), ``publish.yml`` (publishes to PyPI; triggers **only on tag push**,
+  ``tags: v*``, and needs the ``PYPI_API_TOKEN`` secret as ``TWINE_PASSWORD``),
+  plus ``format.yml`` and ``version.yml``.
+
+Documentation
+-------------
+
+- `docs/notebook-setup.md <docs/notebook-setup.md>`_ — how the notebook bootstrap,
+  the ``.env`` / ``PURESKILLGG_TOME_*`` variables, and ``TomeCuratorFs`` fit
+  together to load a local tome collection.
 
 Installation
 ------------
@@ -31,6 +143,7 @@ Install it with
 
 .. _pureskillgg-datascience-showcase: https://pypi.python.org/pypi/pureskillgg-datascience-showcase
 .. _Python Package Index (PyPI): https://pypi.python.org/
+.. _python-dotenv: https://pypi.python.org/pypi/python-dotenv
 
 Development and Testing
 -----------------------

--- a/docs/notebook-setup.md
+++ b/docs/notebook-setup.md
@@ -1,0 +1,101 @@
+# Notebook setup and reading local tomes
+
+This repo's published package exists mainly to bootstrap a Jupyter notebook so it
+can find and read a local PureSkill.gg **tome** data set. This doc explains the
+moving parts. None of this touches the cloud — tomes are read from the local
+filesystem.
+
+## The flow
+
+A notebook starts with three cells:
+
+```python
+from pureskillgg_datascience_showcase.notebook import setup_notebook
+setup_notebook()
+%load ../usual_suspects.py
+```
+
+1. `setup_notebook(silent=False)` calls `setup_env_from_dotenv()` then
+   `echo_paths()`.
+   - `setup_env_from_dotenv()` runs `load_dotenv(os.path.join("..", ".env"))`,
+     i.e. it loads a `.env` file **one directory above the notebook** into the
+     process environment.
+   - `echo_paths()` prints the four tome-related variables so you can confirm the
+     curator will look in the right place. Pass `setup_notebook(silent=True)` to
+     skip the printout.
+2. `%load ../usual_suspects.py` pulls in the shared boilerplate: pandas, numpy,
+   matplotlib, display options, and the one line that matters —
+   `curator = TomeCuratorFs()`.
+
+`TomeCuratorFs` is the **filesystem** tome reader from `pureskillgg_dsdk.tome`
+(the `Fs` suffix = local files, not S3). It reads its collection location from the
+environment, which is why the `.env` must be loaded first.
+
+## The environment variables
+
+`env_setup.py` uses `ENV_PREFIX = "pureskillgg_tome"` and joins it with each name,
+uppercased. So the variables it reads and echoes are:
+
+| Echoed name          | Environment variable                     | Meaning |
+| -------------------- | ---------------------------------------- | ------- |
+| `default_header_name`| `PURESKILLGG_TOME_DEFAULT_HEADER_NAME`   | dsdk tome header name to use by default |
+| `ds_type`            | `PURESKILLGG_TOME_DS_TYPE`               | data-set type for the curator |
+| `collection_path`    | `PURESKILLGG_TOME_COLLECTION_PATH`       | path to the tome collection on disk |
+| `ds_collection_path` | `PURESKILLGG_TOME_DS_COLLECTION_PATH`    | path to the data-set collection on disk |
+
+A minimal `../.env` therefore points the curator at a local tome collection, for
+example:
+
+```dotenv
+PURESKILLGG_TOME_COLLECTION_PATH=H:\CSDS_tomes\
+PURESKILLGG_TOME_DS_COLLECTION_PATH=H:\CSDS_tomes\
+PURESKILLGG_TOME_DS_TYPE=csds
+PURESKILLGG_TOME_DEFAULT_HEADER_NAME=header
+```
+
+If a variable is unset, `echo()` prints `... is not setup`, which is the quickest
+way to debug a notebook that fails to load data.
+
+## Reading tomes two ways
+
+### Pre-built named tome
+
+The analysis notebooks read an already-rolled-up tome dataframe by name and date
+range, for example:
+
+```python
+df = curator.get_dataframe('channel_player_disconnect.2021-05-01,2022-01-01')
+df = curator.get_dataframe('channel_player_death.2022-04-01,2022-06-27.may-missing')
+```
+
+### Building a tome with reading instructions
+
+The template notebook builds a tome on the fly with `make_tome`, selecting
+specific channels and columns via `ds_reading_instructions`, then iterates pages:
+
+```python
+tomer = curator.make_tome(
+    'counter_strafing',
+    header_tome_name="subheader_tome_all",
+    behavior_if_partial='continue',
+    max_page_size_mb=1,
+    ds_reading_instructions=[
+        {"channel": 'player_info', "columns": ['player_id_fixed', 'rank', 'wins', 'round']},
+        {"channel": 'weapon_fire', "columns": ['tick', 'weapon_name', 'player_id_fixed']},
+        {"channel": 'header'},
+        {"channel": 'player_vector', "columns": ['tick', 'player_id_fixed', 'z_vel', 'recoil_index', 'speed_2d', 'duck_amount']},
+    ])
+
+for data, key in tomer.iterate():
+    df = extract_cool_df(data)
+    tomer.concat(df)
+```
+
+## Gotchas
+
+- `pureskillgg_datascience_showcase/env_functions/` has no `__init__.py`;
+  `setup_notebook.py` imports it via `from ..env_functions.env_setup import ...`,
+  relying on implicit namespace-package import.
+- In the M4 notebook the raw `weapon_name` value `m4a1` is the **M4A4**, and
+  `m4a1_silencer` / `m4a1_silencer_off` are the **M4A1-S**. The notebook renames
+  them (`m4a4_kills` / `m4a1_kills`) to avoid confusion.


### PR DESCRIPTION
## What

Replaces the thin `TODO` description in `README.rst` with concrete content while keeping all badges and boilerplate sections (Installation, Development/Testing, Publishing, GitHub Actions secrets, Contributing, License, Warranty) verbatim.

### README.rst changes
- One-line summary describing the repo as a published package + example notebooks for the public PureSkill.gg data set.
- **What it does** — the notebook-bootstrap package (`setup_notebook`, `env_setup`) plus the worked example notebooks (disconnect-reason analysis, M4 June-2022 kill-share, template).
- **Pipeline role** — downstream/consumer end; loads local "tome" data via `TomeCuratorFs`; not part of production match processing; nothing downstream consumes it.
- **Major modules and notebooks** — confirmed components by real name, with the `PURESKILLGG_TOME_*` env vars and dependency notes (dsdk 1.x betas, numpy<2/pandas<2, first uv-migrated repo).
- **Logs and observability** — documents that there are zero cloud resources; failures only surface in dev (Makefile targets) and CI (GitHub Actions `main`/`publish`/`format`/`version`; `publish` on tag push only, needs `PYPI_API_TOKEN`).
- **Documentation** — links to the new deep-dive.

### New doc
- `docs/notebook-setup.md` — how `setup_notebook()`, the `../.env` / `PURESKILLGG_TOME_*` variables, and `TomeCuratorFs` combine to read a local tome collection, including `get_dataframe` vs `make_tome` usage and the namespace-package / `m4a1`=M4A4 gotchas.

## Notes
README stays valid reStructuredText (no Markdown headings/links/fences). The deep-dive is Markdown under `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)