### PR TITLE
Harden the deploy workflows against silent wrong-thing failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 ---
 name: publish
+run-name: Publish ${{ github.ref_name }}
 
 on:
   push:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,5 +1,6 @@
 ---
 name: version
+run-name: Cut ${{ github.event.inputs.version }}${{ github.event.client_payload.version }}
 
 on:
   workflow_dispatch:
@@ -49,8 +50,10 @@ jobs:
       - name: Build
         run: make build
       - name: Cut ${{ github.event.inputs.version }}${{ github.event.client_payload.version }} version
+        env:
+          VERSION: ${{ github.event.inputs.version }}${{ github.event.client_payload.version }}
         run: |
-          version="${{ github.event.inputs.version }}${{ github.event.client_payload.version }}"
+          version="$VERSION"
           if [[ "${version}" =~ [0-9] ]]; then
             uv run bump2version --sign-tags --new-version $version major
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Harden the deploy workflows: pass the version input through `env:` instead of interpolating it into the shell line; give the dispatch and tag workflows readable run titles; serialize deploys with a concurrency group and give every job a timeout.
+- Harden the deploy workflows: pass the version input through `env:` instead of interpolating it into the shell line; give the dispatch and tag workflows readable run titles.
 
 - GitHub Actions updated to Node 24 runtimes: `actions/checkout` v5 to v7; `astral-sh/setup-uv` v6 to v9.0.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Harden the deploy workflows: pass the version input through `env:` instead of interpolating it into the shell line; give the dispatch and tag workflows readable run titles; serialize deploys with a concurrency group and give every job a timeout.
+
 - GitHub Actions updated to Node 24 runtimes: `actions/checkout` v5 to v7; `astral-sh/setup-uv` v6 to v9.0.0.
 
 ## 0.0.4 / 2026-06-13

--- a/uv.lock
+++ b/uv.lock
@@ -3728,7 +3728,7 @@ wheels = [
 
 [[package]]
 name = "pureskillgg-datascience-showcase"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Fleet sweep from the plan in [igl-gotv docs/plans/workflow_hardening_sweep.md](https://github.com/pureskillgg/igl-gotv/blob/master/docs/plans/workflow_hardening_sweep.md), which carries the evidence for each change.

What changed here:

- publish.yml: added run-name
- version.yml: dispatch input moved out of the shell line
- version.yml: added run-name

CHANGELOG updated.

> [!WARNING]
> `version.yml`, `promote.yml`, `publish.yml` and `redeploy.yml` are tag- or dispatch-triggered, so PR CI never exercises them. A green check here does not cover them - they were validated by parsing the YAML.
